### PR TITLE
Add documentation for `&U-i002+2FF1;` IDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ stored in the 3rd field may be regarded as functional structure.
 
 &U-i001+2FFB; <img src="https://glyphwiki.org/glyph/u2ffb-itaiji-001.50px.png" alt="U+2FFB-itaiji-001" title="U+2FFB-itaiji-001">x⿰yz = ⿷⿼xyz
 
+&U-i002+2FF1; <img src="https://glyphwiki.org/glyph/u2ff1-itaiji-002.50px.png" alt="U+2FF1-itaiji-002" title="U+2FF1-itaiji-002">x⿰yz = ⿺⿽xyz
 
 # License
 


### PR DESCRIPTION
This pull request adds a description of the `&U-i002+2FF1;` IDC to the project README.

<img width="403" height="331" alt="idc" src="https://github.com/user-attachments/assets/06cbecde-4a59-401d-b649-1e4fcb2d4cb0" />

This IDC is used frequently throughout the data. For example, here are the five instances in `IDS-UCS-Basic.txt`

```
866:   U+5160    兠      &U-i002+2FF1;北皃
2386:  U+5750    坐      &U-i002+2FF1;从土
2837:  U+5913    夓      ⿱&U-i002+2FF1;𦥑頁夂
19762: U+9B30    鬰      ⿱&U-i002+2FF1;林⿱爻冖⿰鬯彡
19763: U+9B31    鬱      ⿱&U-i002+2FF1;林⿱缶冖⿰鬯彡
```